### PR TITLE
Fix when text is a space or special character one word

### DIFF
--- a/bothub_nlp_nlu_worker/bothub_nlp_nlu/debug_parse.py
+++ b/bothub_nlp_nlu_worker/bothub_nlp_nlu/debug_parse.py
@@ -30,7 +30,7 @@ class DebugSentenceLime:
 
             intent_list = [0] * len(self.intention_names)
             intent_name_list = [""] * len(self.intention_names)
-            size = len(result_json.get("intent_ranking"))
+            size = len(result_json.get("intent_ranking", []))
             for i in range(size):
                 intent_name = result_json.get("intent_ranking")[i].get("name")
                 intent_list[idx_dict[intent_name]] = result_json.get("intent_ranking")[
@@ -54,9 +54,12 @@ class DebugSentenceLime:
             return {}
         explainer = LimeTextExplainer(class_names=self.intention_names)
         labels = list(range(len(self.intention_names)))  # List
-        exp = explainer.explain_instance(
-            text, self.parse, num_features=6, labels=labels, num_samples=num_samples
-        )
+        try:
+            exp = explainer.explain_instance(
+                text, self.parse, num_features=6, labels=labels, num_samples=num_samples
+            )
+        except ValueError:
+            labels = []
         result_per_word = {}
         for label in labels:
             for j in exp.as_list(label=label):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ celery==4.3.0
 git+https://github.com/bothub-it/bothub-backend.git@1.0.7
 redis
 flake8
-git+https://github.com/bothub-it/bothub-nlp-celery.git@0.1.12
+git+https://github.com/bothub-it/bothub-nlp-celery.git@0.1.13
 black==19.3b0
 kombu==4.5.0
 rasa==1.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ celery==4.3.0
 git+https://github.com/bothub-it/bothub-backend.git@1.0.7
 redis
 flake8
-git+https://github.com/bothub-it/bothub-nlp-celery.git@0.1.13
+git+https://github.com/bothub-it/bothub-nlp-celery.git@0.1.15
 black==19.3b0
 kombu==4.5.0
 rasa==1.4.3


### PR DESCRIPTION
When the debug_parse method was calling explainer from lime with a one word it would remove the word and send to the rasa interpreter, the rasa interpreter returned the json classifying the intent with null but without the key "intent_ranking" leading to an error